### PR TITLE
fix: issue when multiple edits on the same line

### DIFF
--- a/internal/lsp/workspace_test.go
+++ b/internal/lsp/workspace_test.go
@@ -129,6 +129,55 @@ func TestApplyEditsToContent(t *testing.T) {
 			},
 			expected: "package main\n\nimport \"os\"\n\nfunc main() {}",
 		},
+		{
+			name:    "multiple edits on same line - config to pkg_config",
+			content: "environment == config.EnvironmentDev || environment == config.EnvironmentProd,",
+			edits: []protocol.TextEdit{
+				{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 0, Character: 15},
+						End:   protocol.Position{Line: 0, Character: 21},
+					},
+					NewText: "pkg_config",
+				},
+				{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 0, Character: 55},
+						End:   protocol.Position{Line: 0, Character: 61},
+					},
+					NewText: "pkg_config",
+				},
+			},
+			expected: "environment == pkg_config.EnvironmentDev || environment == pkg_config.EnvironmentProd,",
+		},
+		{
+			name:    "multiple edits - import statements",
+			content: "import \"fmt\"; import \"os\"; import \"log\"",
+			edits: []protocol.TextEdit{
+				{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 0, Character: 8},
+						End:   protocol.Position{Line: 0, Character: 11},
+					},
+					NewText: "myfmt",
+				},
+				{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 0, Character: 22},
+						End:   protocol.Position{Line: 0, Character: 24},
+					},
+					NewText: "myos",
+				},
+				{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 0, Character: 35},
+						End:   protocol.Position{Line: 0, Character: 38},
+					},
+					NewText: "mylog",
+				},
+			},
+			expected: "import \"myfmt\"; import \"myos\"; import \"mylog\"",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This pull request improves the handling of text edits in the `applyEditsToContent` function by introducing a robust sorting mechanism and enhances test coverage to verify the changes. The key updates include sorting edits in reverse order to prevent offset issues and adding new test cases to ensure correctness when multiple edits occur on the same line or across lines.

### Improvements to `applyEditsToContent` function:

* Introduced sorting of text edits in reverse order (by line and character position) to ensure edits are applied without offset conflicts. This change ensures that character positions remain valid when multiple edits occur on the same line or across lines. (`internal/lsp/workspace.go`, [internal/lsp/workspace.goL101-R123](diffhunk://#diff-a694a1c53803c212be2410b9db8dec25b4a0408bc2f2fbb611ab41e516e42f52L101-R123))

### Enhancements to test coverage:

* Added a test case to verify the behavior when multiple edits occur on the same line, ensuring that the function correctly applies changes without conflicts. (`internal/lsp/workspace_test.go`, [internal/lsp/workspace_test.goR132-R180](diffhunk://#diff-e957db6a508404a5cf8512146ca71f05243276aa79e3a3124b7cb6627c02da66R132-R180))
* Added a test case to handle multiple edits across different parts of a single line, such as modifying import statements, ensuring correctness in complex scenarios. (`internal/lsp/workspace_test.go`, [internal/lsp/workspace_test.goR132-R180](diffhunk://#diff-e957db6a508404a5cf8512146ca71f05243276aa79e3a3124b7cb6627c02da66R132-R180))

### Minor updates:

* Added the `sort` package import to support sorting functionality. (`internal/lsp/workspace.go`, [internal/lsp/workspace.goR6](diffhunk://#diff-a694a1c53803c212be2410b9db8dec25b4a0408bc2f2fbb611ab41e516e42f52R6))