### PR TITLE
chore: bump Go version to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jackchuka/goalias
 
-go 1.26.1
+go 1.26.5
 
 require (
 	github.com/spf13/cobra v1.10.2


### PR DESCRIPTION
## Summary
- Bumps the Go version directive in `go.mod` from `1.26.1` to `1.26.5`.
- Go 1.26.5 (released 2026-07-07) includes security fixes to `crypto/tls` and `os`.

## Verification
- `go mod tidy`: clean (no changes to `go.sum`).
- `go test ./...`: all tests pass, verified locally on macOS/arm64.